### PR TITLE
VS-6793: Cornet .NET 8 upgrade

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Description
+
+<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
+
+:information_source: [**Jira Ticket Number here**](Jira web address here)  
+
+* List changes here
+
+## Type of change
+
+<!-- Please delete options that are not relevant. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/workflows/cd-cornet-interface-service.yaml
+++ b/.github/workflows/cd-cornet-interface-service.yaml
@@ -1,0 +1,48 @@
+name: cd-cornet-interface-service
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'CornetInterfaceService/**'
+      - '.github/workflows/cd-cornet-interface-service.yml'
+
+env:
+  BUILD_ID: ${{ github.server_url }}!${{ github.repository }}!${{ github.ref_name }}!${{ github.sha }}!${{ github.run_number }}
+  IMAGE_NAME: vsu
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+
+jobs:
+  build-cornet-interface-service:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+    env:
+      CORNET_INTERFACE_SERVICE_DOCKERFILE_PATH: ./CornetInterfaceService/CornetInterfaceService/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx tooling
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into OpenShift Registry
+        uses: docker/login-action@v3
+        with:
+            registry: ${{ env.IMAGE_REGISTRY }}
+            username: ${{ secrets.OCP4_USERNAME }}
+            password: ${{ secrets.OCP4_PASSWORD }}
+
+      - name: Pull image
+        run: docker pull $IMAGE_ID || true
+
+      - name: Build and push vsu-app
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            BUILD_ID="${{ env.BUILD_ID }}"
+          cache-from: |
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          file: ${{ env.CORNET_INTERFACE_SERVICE_DOCKERFILE_PATH }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:dev

--- a/CornetInterfaceService/CornetInterfaceService/cornet-interface-service.csproj
+++ b/CornetInterfaceService/CornetInterfaceService/cornet-interface-service.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>a6a87a1a-3244-4983-bfcd-dd663b9c7632</UserSecretsId>
   </PropertyGroup>
 
@@ -11,11 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="3.1.25" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.6" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
-    <PackageReference Include="RestSharp" Version="106.6.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.3.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
   </ItemGroup>
 
 </Project>

--- a/CornetInterfaceService/Dockerfile
+++ b/CornetInterfaceService/Dockerfile
@@ -1,0 +1,31 @@
+ARG BUILD_ID
+
+# Retrieve and set base image layer
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG BUILD_ID
+ARG BUILD_VERSION
+WORKDIR /app
+
+# Create build image for runtime
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+COPY . .
+
+# Restore as distinct layers
+RUN dotnet restore "./CornetInterfaceService/CornetInterfaceService/cornet-interface-service.csproj"
+RUN dotnet build "CornetInterfaceService/CornetInterfaceService/cornet-interface-service.csproj" -c Release -o /app/build
+
+# Create publish image layer
+FROM build AS publish
+ARG BUILD_ID
+COPY . .
+
+# Build and publish a release
+RUN dotnet publish "CornetInterfaceService/CornetInterfaceService/cornet-interface-service.csproj" -c Release -o /app/publish
+
+# Build runtime image
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+ENTRYPOINT ["dotnet", "cornet-interface-service.dll"]


### PR DESCRIPTION
`CornetInterfaceService` has now been upgraded to .NET 8 as part of COAST's overall .NET upgrade effort. Additionally, all packages have been upgraded to the latest versions compatible with .NET 8, and Docker has now been implemented to replace the legacy `s2i` build process.

GitHub Actions will now also handle image builds rather than OpenShift Tekton pipelines.