### PR TITLE
VS-6728: Fix CAS image name, workflow trigger path

### DIFF
--- a/.github/workflows/cd-cas-interface-service.yaml
+++ b/.github/workflows/cd-cas-interface-service.yaml
@@ -5,11 +5,11 @@ on:
   push:
     paths:
       - 'CASInterfaceService/**'
-      - '.github/workflows/cd-cas-interface-service.yml'
+      - '.github/workflows/cd-cas-interface-service.yaml'
 
 env:
   BUILD_ID: ${{ github.server_url }}!${{ github.repository }}!${{ github.ref_name }}!${{ github.sha }}!${{ github.run_number }}
-  IMAGE_NAME: vsu
+  IMAGE_NAME: cas-interface-service
   IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
 
 jobs:


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes an error in CAS' new GitHub Actions workflow where it is incorrectly pushing to another image stream; this rectifies it as well correcting the trigger path for when modifications are made to the workflow itself.

:information_source: [**VS-6728**](https://jag.gov.bc.ca/jira/browse/VS-6728)  

* `.github/workflows/cd-cas-interface-service.yaml`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
