### PR TITLE
COASTD365-146: Add support for YARP reverse proxy.

### DIFF
--- a/CornetInterfaceService/CornetInterfaceService/Program.cs
+++ b/CornetInterfaceService/CornetInterfaceService/Program.cs
@@ -66,7 +66,15 @@ namespace CASInterfaceService
         }
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
+            WebHost
+                .CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(
+                    (hostingContext, configBuilder) =>
+                    {
+                        // Load the Yarp reverse proxy configuration
+                        configBuilder.AddJsonFile("yarp.reverseproxy.json", optional: true, reloadOnChange: true);
+                    }
+                )
                 .UseStartup<Startup>();
 
         public void CallCAS()

--- a/CornetInterfaceService/CornetInterfaceService/Startup.cs
+++ b/CornetInterfaceService/CornetInterfaceService/Startup.cs
@@ -1,20 +1,18 @@
 ﻿using System;
 using System.Net.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpLogging;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
 using Serilog;
 using Serilog.Exceptions;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.IdentityModel.Tokens;
-using System.Security.Claims;
-using System.Threading.Tasks;
-
 
 namespace CASInterfaceService
 {
@@ -35,7 +33,6 @@ namespace CASInterfaceService
                 .AddAuthentication(options =>
                 {
                     options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
-
                 })
                 .AddJwtBearer(
                     JwtBearerDefaults.AuthenticationScheme,
@@ -72,7 +69,9 @@ namespace CASInterfaceService
                             {
                                 await Task.CompletedTask;
 
-                                var userId = ctx.Principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? ctx.Principal?.FindFirst("sub")?.Value;
+                                var userId =
+                                    ctx.Principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                                    ?? ctx.Principal?.FindFirst("sub")?.Value;
 
                                 Console.WriteLine($"JWT - Token validated. UserId: {userId}");
                             },
@@ -86,7 +85,9 @@ namespace CASInterfaceService
                             {
                                 await Task.CompletedTask;
 
-                                Console.WriteLine($"JWT - Challenge. Error: {ctx.Error}; Description: {ctx.ErrorDescription}");
+                                Console.WriteLine(
+                                    $"JWT - Challenge. Error: {ctx.Error}; Description: {ctx.ErrorDescription}"
+                                );
                             },
                         };
 
@@ -101,7 +102,9 @@ namespace CASInterfaceService
                     JwtBearerDefaults.AuthenticationScheme,
                     policy =>
                     {
-                        policy.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme).RequireAuthenticatedUser();
+                        policy
+                            .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
+                            .RequireAuthenticatedUser();
                     }
                 );
 
@@ -125,10 +128,9 @@ namespace CASInterfaceService
 
             services.AddSerilog();
 
-            services.AddMvc(opts =>
-            {
-                opts.EnableEndpointRouting = false;
-            }).SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            services.AddMvc();
+
+            services.AddReverseProxy().LoadFromConfig(Configuration.GetSection("ReverseProxy"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -162,6 +164,7 @@ namespace CASInterfaceService
             {
                 endpoints.MapControllers();
                 endpoints.MapHealthChecks("/hc");
+                endpoints.MapReverseProxy();
             });
 
             if (
@@ -181,7 +184,6 @@ namespace CASInterfaceService
 
                 // Fix for bad SSL issues
 
-
                 Log.Logger = new LoggerConfiguration()
                     .Enrich.FromLogContext()
                     .Enrich.WithExceptionDetails()
@@ -197,7 +199,7 @@ namespace CASInterfaceService
                             ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
                             {
                                 return true;
-                            }
+                            },
                         }
 #pragma warning restore CA2000 // Dispose objects before losing scope
                     )
@@ -229,9 +231,6 @@ namespace CASInterfaceService
             app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseCookiePolicy();
-
-
-            app.UseMvc();
         }
     }
 }

--- a/CornetInterfaceService/CornetInterfaceService/cornet-interface-service.csproj
+++ b/CornetInterfaceService/CornetInterfaceService/cornet-interface-service.csproj
@@ -1,28 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <UserSecretsId>a6a87a1a-3244-4983-bfcd-dd663b9c7632</UserSecretsId>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <UserSecretsId>a6a87a1a-3244-4983-bfcd-dd663b9c7632</UserSecretsId>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="Pages\Controllers\StudentRetriveController.cs" />
-    <Content Include="Pages\Models\CASAPTransaction.cs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Content Include="Pages\Controllers\StudentRetriveController.cs" />
+        <Content Include="Pages\Models\CASAPTransaction.cs" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.26" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
-    <PackageReference Include="RestSharp" Version="112.1.0" />
-    <PackageReference Include="Serilog" Version="4.0.2" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
-    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.Splunk" Version="5.0.1" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.26" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="8.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
+        <PackageReference Include="RestSharp" Version="112.1.0" />
+        <PackageReference Include="Serilog" Version="4.0.2" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+        <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog.Sinks.Splunk" Version="5.0.1" />
+        <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Shared.Database\Shared.Database.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\Shared.Database\Shared.Database.csproj" />
+    </ItemGroup>
 </Project>

--- a/CornetInterfaceService/README.md
+++ b/CornetInterfaceService/README.md
@@ -2,3 +2,33 @@
 
 This is an interface between Cornet and Dynamics. It's a clone of the CASInterfaceService where the prototype was developed, with the CAS interface specific code removed so that the only function remaining is Cornet related.
 
+## Reverse Proxy Configuration
+
+_See https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/yarp/config-files._
+
+Proxies all requests to `<host>/CorVSUDynAPI/*` to `<new_host>/CorVSUDynAPI/*`.
+
+```
+{
+  "ReverseProxy": {
+    "Routes": {
+      "CorVSUDynAPI": {
+        "ClusterId": "CorVSUDynAPI",
+        "AuthorizationPolicy": "default",
+        "Match": {
+          "Path": "/CorVSUDynAPI/{**remainder}"
+        }
+      }
+    },
+    "Clusters": {
+      "CorVSUDynAPI": {
+        "Destinations": {
+          "CorVSUDynAPI": {
+            "Address": "https://wsgw.dev.jag.gov.bc.ca"
+          }
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
## Ticket

https://jira.justice.gov.bc.ca/browse/COASTD365-146

## Changes

Add support for YARP reverse proxy, to solve the issue of Cloud Dynamics no longer being able to call endpoints on the webservice gateway.

## Testing
Vamsi has done some testing and made the dynamics changes on his end and confirmed these changes are working.

## Openshift

The yarp proxy configuration lives in config-map: `coast-cornet-proxy-config`.
Rohith has already added it to the deployment in argo.