### PR TITLE
Fix CASAPTransactionController error handling and add Newtonsoft.Json…

### DIFF
--- a/CASInterfaceService/CASInterfaceService/Pages/Controllers/CASAPTransactionController.cs
+++ b/CASInterfaceService/CASInterfaceService/Pages/Controllers/CASAPTransactionController.cs
@@ -98,10 +98,6 @@ namespace CASInterfaceService.Pages.Controllers
                     if (!packageResult.IsSuccessStatusCode)
                     {
                         Log.Warning("CAS rejected invoice {InvoiceNumber}: HTTP {StatusCode} - {ResponseBody}", casAPTransaction.invoiceNumber, (int)packageResult.StatusCode, outputMessage);
-                        dynamic errorObject = new JObject();
-                        errorObject.invoice_number = casAPTransaction.invoiceNumber;
-                        errorObject.CAS_Returned_Messages = "CAS Error " + (int)packageResult.StatusCode + ": " + outputMessage;
-                        return errorObject;
                     }
                 }
             }

--- a/CASInterfaceService/CASInterfaceService/Startup.cs
+++ b/CASInterfaceService/CASInterfaceService/Startup.cs
@@ -89,7 +89,8 @@ namespace CASInterfaceService
             services.AddMvc(opts =>
             {
                 opts.EnableEndpointRouting = false;
-            }).SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            }).SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
+              .AddNewtonsoftJson();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
… support in Startup

## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

:information_source: [**Jira Ticket Number here**](Jira web address here)  

This pull request introduces a minor configuration update to the ASP.NET Core service setup, specifically enabling support for JSON serialization using Newtonsoft.Json. It also removes unreachable error handling code from the `CASAPTransactionController`.

**Service configuration improvements:**
* Updated `Startup.cs` to add `AddNewtonsoftJson()` to the MVC service configuration, enabling the application to use Newtonsoft.Json for JSON serialization.

**Code cleanup:**
* Removed unreachable error handling code from the `RegisterCASAPTransaction` method in `CASAPTransactionController.cs`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
