### PR TITLE
Refactor date handling and logging for DST compliance

### DIFF
--- a/AEMInterfaceService/AEMInterfaceService/Dockerfile
+++ b/AEMInterfaceService/AEMInterfaceService/Dockerfile
@@ -29,6 +29,9 @@ FROM base AS final
 WORKDIR /app
 RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
 
+# Install tzdata so TimeZoneInfo can resolve IANA timezone names on Alpine.
+RUN apk add --no-cache tzdata
+
 # Accept build args and export as environment variables
 ARG BUILD_ID
 ARG BUILD_VERSION

--- a/AEMInterfaceService/AEMInterfaceService/Pages/Controllers/AEMTransactionController.cs
+++ b/AEMInterfaceService/AEMInterfaceService/Pages/Controllers/AEMTransactionController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Net;
@@ -41,7 +41,7 @@ namespace AEMInterfaceService.Pages.Controllers
             [FromBody] AEMTransaction aemTransaction
         )
         {
-            Console.WriteLine(DateTime.Now + " In RegisterAEMTransaction");
+            Console.WriteLine(DateTime.UtcNow + " In RegisterAEMTransaction");
 
             // Set code to read secrets
             var builder = new ConfigurationBuilder().AddEnvironmentVariables().AddUserSecrets<Program>(); // must also define a project guid for secrets in the .cspro – add tag <UserSecretsId> containing a guid
@@ -49,11 +49,11 @@ namespace AEMInterfaceService.Pages.Controllers
 
             //TODO update these to be stored secrets
             string uri = Configuration["ORACLE_CONNECTION_URL"];
-            Console.WriteLine(DateTime.Now + " Got Oracle Connection URL");
+            Console.WriteLine(DateTime.UtcNow + " Got Oracle Connection URL");
 
             string username = Configuration["ORACLE_URL_USERID"];
             string password = Configuration["ORACLE_URL_PASSWORD"];
-            Console.WriteLine(DateTime.Now + " Got Login/Password information");
+            Console.WriteLine(DateTime.UtcNow + " Got Login/Password information");
 
             HttpClient _client = new HttpClient();
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
@@ -61,7 +61,7 @@ namespace AEMInterfaceService.Pages.Controllers
                 Convert.ToBase64String(System.Text.ASCIIEncoding.ASCII.GetBytes($"{username}:{password}"))
             );
 
-            Console.WriteLine(DateTime.Now + " About to start Step 1");
+            Console.WriteLine(DateTime.UtcNow + " About to start Step 1");
 
             //step 1 - get render_url
             string endpointUrl2 =
@@ -69,26 +69,26 @@ namespace AEMInterfaceService.Pages.Controllers
                 + "/adobeords/web/adobegetrenderurl?document_format="
                 + aemTransaction.document_format
                 + "&policy=victim";
-            Console.WriteLine(DateTime.Now + " Got Endpoint: " + endpointUrl2);
+            Console.WriteLine(DateTime.UtcNow + " Got Endpoint: " + endpointUrl2);
             HttpRequestMessage _httpRequest2 = new HttpRequestMessage(HttpMethod.Get, endpointUrl2);
-            Console.WriteLine(DateTime.Now + " Made httpRequest: " + _httpRequest2.RequestUri);
+            Console.WriteLine(DateTime.UtcNow + " Made httpRequest: " + _httpRequest2.RequestUri);
             var _httpResponse2 = await _client.SendAsync(_httpRequest2);
-            Console.WriteLine(DateTime.Now + " Got response: " + _httpResponse2.StatusCode);
+            Console.WriteLine(DateTime.UtcNow + " Got response: " + _httpResponse2.StatusCode);
             AdobeGetRenderURLResponse _responseContent2 =
                 await _httpResponse2.Content.ReadAsAsync<AdobeGetRenderURLResponse>();
-            Console.WriteLine(DateTime.Now + " Step 1 Complete");
+            Console.WriteLine(DateTime.UtcNow + " Step 1 Complete");
 
             //step 3 - get content_guid
             // Convert xml from base 64 to xml string
             var tempAEMXML = System.Xml.Linq.XElement.Load(
                 new System.IO.MemoryStream(Convert.FromBase64String(aemTransaction.aem_xml_data))
             );
-            Console.WriteLine(DateTime.Now + " Working with this XML: " + tempAEMXML);
+            Console.WriteLine(DateTime.UtcNow + " Working with this XML: " + tempAEMXML);
             //string endpointUrl = uri + "/adobeords/web/adobesavexml?documentContentText=" + tempAEMXML.ToString(System.Xml.Linq.SaveOptions.DisableFormatting);
             string endpointUrl = uri + "/adobeords/web/adobesavexml";
-            Console.WriteLine(DateTime.Now + " Got the endpoint: " + endpointUrl);
+            Console.WriteLine(DateTime.UtcNow + " Got the endpoint: " + endpointUrl);
             HttpRequestMessage _httpRequest = new HttpRequestMessage(HttpMethod.Post, endpointUrl);
-            Console.WriteLine(DateTime.Now + " Made the _httpRequest");
+            Console.WriteLine(DateTime.UtcNow + " Made the _httpRequest");
 
             var jsonRequest = string.Format(
                     "$!$\"documentContentText\":\"{0}\"$&$",
@@ -97,40 +97,40 @@ namespace AEMInterfaceService.Pages.Controllers
                 .Replace("$!$", "{")
                 .Replace("$&$", "}");
             _httpRequest.Content = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
-            Console.WriteLine(DateTime.Now + " Created the httpRequest.Content: " + jsonRequest);
+            Console.WriteLine(DateTime.UtcNow + " Created the httpRequest.Content: " + jsonRequest);
 
             var _httpResponse = await _client.SendAsync(_httpRequest);
-            Console.WriteLine(DateTime.Now + " Sent for _httpResponse: " + _httpResponse);
+            Console.WriteLine(DateTime.UtcNow + " Sent for _httpResponse: " + _httpResponse);
 
             AdobeSaveXMLResponse _responseContent = await _httpResponse.Content.ReadAsAsync<AdobeSaveXMLResponse>();
-            Console.WriteLine(DateTime.Now + " Got ResponseContent:" + _responseContent);
-            Console.WriteLine(DateTime.Now + " Step 2 Complete: " + _responseContent.pKey);
+            Console.WriteLine(DateTime.UtcNow + " Got ResponseContent:" + _responseContent);
+            Console.WriteLine(DateTime.UtcNow + " Step 2 Complete: " + _responseContent.pKey);
 
             //step 3 - call render_url with updated params?? Need clarification on what to do after step 1 and 2
             string endpointUrl3 = _responseContent2.render_url;
-            Console.WriteLine(DateTime.Now + " Got Endpoint: " + endpointUrl3);
-            Console.WriteLine(DateTime.Now + " About to update <<APP>: " + aemTransaction.AEMApp);
+            Console.WriteLine(DateTime.UtcNow + " Got Endpoint: " + endpointUrl3);
+            Console.WriteLine(DateTime.UtcNow + " About to update <<APP>: " + aemTransaction.AEMApp);
             endpointUrl3 = endpointUrl3.Replace("<<APP>>", aemTransaction.AEMApp);
-            Console.WriteLine(DateTime.Now + " About to update <<FORM>: " + aemTransaction.AEMForm);
+            Console.WriteLine(DateTime.UtcNow + " About to update <<FORM>: " + aemTransaction.AEMForm);
             endpointUrl3 = endpointUrl3.Replace("<<FORM>>", aemTransaction.AEMForm);
-            Console.WriteLine(DateTime.Now + " About to update <<TICKET>: " + _responseContent.pKey);
+            Console.WriteLine(DateTime.UtcNow + " About to update <<TICKET>: " + _responseContent.pKey);
             endpointUrl3 = endpointUrl3.Replace("<<TICKET>>", _responseContent.pKey);
             endpointUrl3 = endpointUrl3.Replace(Configuration["RESPONSE_URL"], Configuration["GATEWAY_URL"]);
             endpointUrl3 = endpointUrl3.Replace("https://prod.", "https://"); // This is a little workaround to get rid of the PROD prefix in PROD environment, if it exists
-            Console.WriteLine(DateTime.Now + " Fixed Endpoint: " + endpointUrl3);
-            Console.WriteLine(DateTime.Now + " Step 3 Complete");
+            Console.WriteLine(DateTime.UtcNow + " Fixed Endpoint: " + endpointUrl3);
+            Console.WriteLine(DateTime.UtcNow + " Step 3 Complete");
 
             AEMTransactionRegistrationReply aemregreply = new AEMTransactionRegistrationReply();
             AEMTransactionRegistration.getInstance().Add(aemTransaction);
 
-            Console.WriteLine(DateTime.Now + " Received data from Dynamics");
+            Console.WriteLine(DateTime.UtcNow + " Received data from Dynamics");
 
             try
             {
                 // Now we're just sending the URL back to Dynamics
                 aemregreply.ResponseCode = "200";
                 aemregreply.ResponseMessage = endpointUrl3;
-                Console.WriteLine(DateTime.Now + " Response Success");
+                Console.WriteLine(DateTime.UtcNow + " Response Success");
             }
             catch (Exception e)
             {
@@ -138,7 +138,7 @@ namespace AEMInterfaceService.Pages.Controllers
                 aemregreply.ResponseMessage = e.Message;
             }
 
-            Console.WriteLine(DateTime.Now + " Exit RegisterAEMTransaction");
+            Console.WriteLine(DateTime.UtcNow + " Exit RegisterAEMTransaction");
             return aemregreply;
         }
 
@@ -151,7 +151,7 @@ namespace AEMInterfaceService.Pages.Controllers
         public async Task<IActionResult> RegisterAndRetrievePdf([FromBody] AEMTransaction aemTransaction)
         {
             Console.WriteLine(
-                DateTime.Now
+                DateTime.UtcNow
                     + " In RegisterAndRetrievePdf - aem_app="
                     + aemTransaction.AEMApp
                     + " aem_form="
@@ -180,12 +180,12 @@ namespace AEMInterfaceService.Pages.Controllers
                 + aemTransaction.document_format
                 + "&policy=victim";
 
-            Console.WriteLine(DateTime.Now + " RegisterAndRetrievePdf: Step 1 - " + renderUrlEndpoint);
+            Console.WriteLine(DateTime.UtcNow + " RegisterAndRetrievePdf: Step 1 - " + renderUrlEndpoint);
 
             var renderUrlResponse = await client.GetAsync(renderUrlEndpoint);
 
             Console.WriteLine(
-                DateTime.Now + " RegisterAndRetrievePdf: Step 1 - response " + renderUrlResponse.StatusCode
+                DateTime.UtcNow + " RegisterAndRetrievePdf: Step 1 - response " + renderUrlResponse.StatusCode
             );
 
             if (!renderUrlResponse.IsSuccessStatusCode)
@@ -195,7 +195,7 @@ namespace AEMInterfaceService.Pages.Controllers
                 await renderUrlResponse.Content.ReadAsAsync<AdobeGetRenderURLResponse>();
 
             Console.WriteLine(
-                DateTime.Now + " RegisterAndRetrievePdf: Step 1 Complete - render_url=" + renderUrlContent.render_url
+                DateTime.UtcNow + " RegisterAndRetrievePdf: Step 1 Complete - render_url=" + renderUrlContent.render_url
             );
 
             // Step 2 – save XML to AEM to get the pKey (ticket)
@@ -205,7 +205,7 @@ namespace AEMInterfaceService.Pages.Controllers
 
             string saveXmlEndpoint = uri + "/adobeords/web/adobesavexml";
 
-            Console.WriteLine(DateTime.Now + " RegisterAndRetrievePdf: Step 2 - " + saveXmlEndpoint);
+            Console.WriteLine(DateTime.UtcNow + " RegisterAndRetrievePdf: Step 2 - " + saveXmlEndpoint);
 
             var jsonRequest = string.Format(
                     "$!$\"documentContentText\":\"{0}\"$&$",
@@ -220,7 +220,7 @@ namespace AEMInterfaceService.Pages.Controllers
             var saveXmlResponse = await client.SendAsync(saveXmlRequest);
 
             Console.WriteLine(
-                DateTime.Now + " RegisterAndRetrievePdf: Step 2 - response " + saveXmlResponse.StatusCode
+                DateTime.UtcNow + " RegisterAndRetrievePdf: Step 2 - response " + saveXmlResponse.StatusCode
             );
 
             if (!saveXmlResponse.IsSuccessStatusCode)
@@ -228,7 +228,7 @@ namespace AEMInterfaceService.Pages.Controllers
 
             AdobeSaveXMLResponse saveXmlContent = await saveXmlResponse.Content.ReadAsAsync<AdobeSaveXMLResponse>();
 
-            Console.WriteLine(DateTime.Now + " RegisterAndRetrievePdf: Step 2 Complete");
+            Console.WriteLine(DateTime.UtcNow + " RegisterAndRetrievePdf: Step 2 Complete");
 
             // Step 3 – resolve placeholders to build the PDF URL
             string pdfUrl = renderUrlContent.render_url;
@@ -238,16 +238,16 @@ namespace AEMInterfaceService.Pages.Controllers
             pdfUrl = pdfUrl.Replace(configuration["RESPONSE_URL"], configuration["GATEWAY_URL"]);
             pdfUrl = pdfUrl.Replace("https://prod.", "https://");
 
-            Console.WriteLine(DateTime.Now + " RegisterAndRetrievePdf: Step 3 Complete - resolved PDF URL: " + pdfUrl);
+            Console.WriteLine(DateTime.UtcNow + " RegisterAndRetrievePdf: Step 3 Complete - resolved PDF URL: " + pdfUrl);
 
             AEMTransactionRegistration.getInstance().Add(aemTransaction);
 
             // Step 4 – fetch the PDF and return it directly to the caller
-            Console.WriteLine(DateTime.Now + " RegisterAndRetrievePdf: Step 4 - fetching PDF");
+            Console.WriteLine(DateTime.UtcNow + " RegisterAndRetrievePdf: Step 4 - fetching PDF");
 
             var pdfResponse = await client.GetAsync(pdfUrl, HttpCompletionOption.ResponseHeadersRead);
 
-            Console.WriteLine(DateTime.Now + " RegisterAndRetrievePdf: Step 4 - response " + pdfResponse.StatusCode);
+            Console.WriteLine(DateTime.UtcNow + " RegisterAndRetrievePdf: Step 4 - response " + pdfResponse.StatusCode);
 
             if (!pdfResponse.IsSuccessStatusCode)
                 return StatusCode((int)pdfResponse.StatusCode, "AEM returned an error when fetching the PDF.");
@@ -256,14 +256,14 @@ namespace AEMInterfaceService.Pages.Controllers
 
             string contentType = pdfResponse.Content.Headers.ContentType?.ToString() ?? "application/pdf";
 
-            Console.WriteLine(DateTime.Now + " Exit RegisterAndRetrievePdf");
+            Console.WriteLine(DateTime.UtcNow + " Exit RegisterAndRetrievePdf");
 
             return File(pdfStream, contentType);
         }
 
         private static async Task<string> CallDynamicsWithAEMData(IConfiguration configuration, AEMTransaction model)
         {
-            Console.WriteLine(DateTime.Now + " In CallDynamicsWithAEMData");
+            Console.WriteLine(DateTime.UtcNow + " In CallDynamicsWithAEMData");
             HttpClient httpClient = null;
             try
             {
@@ -275,9 +275,9 @@ namespace AEMInterfaceService.Pages.Controllers
 
                 // Get results into the tuple
                 var endpointAction = "vsd_CreateCORNETNotifications";
-                Console.WriteLine(DateTime.Now + " Set endpoint " + endpointAction);
+                Console.WriteLine(DateTime.UtcNow + " Set endpoint " + endpointAction);
                 var tuple = await GetDynamicsHttpClientNew(configuration, aemJson, endpointAction);
-                Console.WriteLine(DateTime.Now + " Got result from Dynamics");
+                Console.WriteLine(DateTime.UtcNow + " Got result from Dynamics");
 
                 string tempResult = tuple.Item1.ToString();
 
@@ -300,7 +300,7 @@ namespace AEMInterfaceService.Pages.Controllers
                     dynamicsResponse.odatacontext = dynamicsResponse.Result;
                 }
 
-                Console.WriteLine(DateTime.Now + " Return results from Dynamics");
+                Console.WriteLine(DateTime.UtcNow + " Return results from Dynamics");
                 return dynamicsResponse.odatacontext;
             }
             finally
@@ -316,10 +316,10 @@ namespace AEMInterfaceService.Pages.Controllers
             String endPointName
         )
         {
-            Console.WriteLine(DateTime.Now + " In GetDynamicsHttpClientNew");
+            Console.WriteLine(DateTime.UtcNow + " In GetDynamicsHttpClientNew");
             var builder = new ConfigurationBuilder().AddEnvironmentVariables().AddUserSecrets<Program>();
             var Configuration = builder.Build();
-            Console.WriteLine(DateTime.Now + " Build Configuration");
+            Console.WriteLine(DateTime.UtcNow + " Build Configuration");
 
             // Bind Dynamics configuration
             var dynamicsOptions =
@@ -332,7 +332,7 @@ namespace AEMInterfaceService.Pages.Controllers
                 throw new Exception("Configuration setting for DynamicsApiEndpointUrl is blank.");
             }
 
-            Console.WriteLine(DateTime.Now + " Variables have been set");
+            Console.WriteLine(DateTime.UtcNow + " Variables have been set");
 
             try
             {
@@ -347,7 +347,7 @@ namespace AEMInterfaceService.Pages.Controllers
 
                 // Acquire token
                 string token = await tokenProvider.AcquireToken();
-                Console.WriteLine(DateTime.Now + " Got a token");
+                Console.WriteLine(DateTime.UtcNow + " Got a token");
 
                 // Call Dynamics
                 using var client = new HttpClient();
@@ -357,29 +357,29 @@ namespace AEMInterfaceService.Pages.Controllers
                 client.DefaultRequestHeaders.Add("Accept", "application/json");
 
                 string url = dynamicsOdataUri + endPointName;
-                Console.WriteLine(DateTime.Now + " Set full URL to speak to Dynamics: " + url);
+                Console.WriteLine(DateTime.UtcNow + " Set full URL to speak to Dynamics: " + url);
 
                 HttpRequestMessage _httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
                 _httpRequest.Content = new StringContent(model, Encoding.UTF8, "application/json");
-                Console.WriteLine(DateTime.Now + " Got HTTP Request ready");
+                Console.WriteLine(DateTime.UtcNow + " Got HTTP Request ready");
 
                 var _httpResponse = await client.SendAsync(_httpRequest);
                 HttpStatusCode _statusCode = _httpResponse.StatusCode;
 
                 var _responseString = _httpResponse.ToString();
-                Console.WriteLine(DateTime.Now + " Got HTTP Response");
+                Console.WriteLine(DateTime.UtcNow + " Got HTTP Response");
                 var _responseContent = await _httpResponse.Content.ReadAsStringAsync();
 
-                Console.Out.WriteLine(DateTime.Now + " model: " + model);
-                Console.Out.WriteLine(DateTime.Now + " responseString: " + _responseString);
-                Console.Out.WriteLine(DateTime.Now + " responseContent: " + _responseContent);
+                Console.Out.WriteLine(DateTime.UtcNow + " model: " + model);
+                Console.Out.WriteLine(DateTime.UtcNow + " responseString: " + _responseString);
+                Console.Out.WriteLine(DateTime.UtcNow + " responseContent: " + _responseContent);
 
-                Console.WriteLine(DateTime.Now + " Exit GetDynamicsHttpClientNew");
+                Console.WriteLine(DateTime.UtcNow + " Exit GetDynamicsHttpClientNew");
                 return new Tuple<int, HttpResponseMessage, string>((int)_statusCode, _httpResponse, _responseContent);
             }
             catch (Exception e)
             {
-                Console.WriteLine(DateTime.Now + " Error in GetDynamicsHttpClientNew: " + e.Message);
+                Console.WriteLine(DateTime.UtcNow + " Error in GetDynamicsHttpClientNew: " + e.Message);
                 return new Tuple<int, HttpResponseMessage, string>(100, null, "Error: " + e.Message);
             }
         }
@@ -389,7 +389,7 @@ namespace AEMInterfaceService.Pages.Controllers
         {
             try
             {
-                Console.WriteLine(DateTime.Now + " In InsertCornetTransaction");
+                Console.WriteLine(DateTime.UtcNow + " In InsertCornetTransaction");
                 CornetTransactionRegistrationReply casregreply = new CornetTransactionRegistrationReply();
                 CornetTransactionRegistration.getInstance().Add(cornetTransaction);
                 casregreply.ResponseMessage = "Success";
@@ -398,7 +398,7 @@ namespace AEMInterfaceService.Pages.Controllers
             }
             catch (Exception e)
             {
-                Console.WriteLine(DateTime.Now + " Error in InsertCornetTransaction. " + e.ToString());
+                Console.WriteLine(DateTime.UtcNow + " Error in InsertCornetTransaction. " + e.ToString());
                 return StatusCode(e.HResult);
             }
         }

--- a/AEMInterfaceService/AEMInterfaceService/Pages/Controllers/CASAPRetrieveController.cs
+++ b/AEMInterfaceService/AEMInterfaceService/Pages/Controllers/CASAPRetrieveController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -50,14 +50,14 @@ namespace AEMInterfaceService.Pages.Controllers
             secret = headers["secret"].ToString();
             clientID = headers["clientID"].ToString();
 
-            Console.WriteLine(DateTime.Now + " In RegisterCASAPTransaction");
+            Console.WriteLine(DateTime.UtcNow + " In RegisterCASAPTransaction");
             CASAPTransactionRegistrationReply casregreply = new CASAPTransactionRegistrationReply();
             CASAPQueryRegistration.getInstance().Add(casAPQuery);
 
             try
             {
                 // Start by getting token
-                Console.WriteLine(DateTime.Now + " Starting sendTransactionsToCAS (CASAPRetreiveController).");
+                Console.WriteLine(DateTime.UtcNow + " Starting sendTransactionsToCAS (CASAPRetreiveController).");
 
                 // Get secret information
                 Console.WriteLine("Get Secret information.");
@@ -69,7 +69,7 @@ namespace AEMInterfaceService.Pages.Controllers
                 TokenURL = Configuration["CAS_API_URI"] + "oauth/token"; // CAS AP Token URL
 
                 HttpClientHandler handler = new HttpClientHandler();
-                Console.WriteLine(DateTime.Now + " GET: + " + TokenURL);
+                Console.WriteLine(DateTime.UtcNow + " GET: + " + TokenURL);
 
                 HttpClient client = new HttpClient(handler);
 
@@ -80,7 +80,7 @@ namespace AEMInterfaceService.Pages.Controllers
                 var formData = new List<KeyValuePair<string, string>>();
                 formData.Add(new KeyValuePair<string, string>("grant_type", "client_credentials"));
 
-                Console.WriteLine(DateTime.Now + " Add credentials");
+                Console.WriteLine(DateTime.UtcNow + " Add credentials");
                 request.Content = new FormUrlEncodedContent(formData);
                 var response = await client.SendAsync(request);
 
@@ -93,7 +93,7 @@ namespace AEMInterfaceService.Pages.Controllers
                 var jo = JObject.Parse(responseBody);
                 string responseToken = jo["access_token"].ToString();
 
-                Console.WriteLine(DateTime.Now + " Received token successfully, now to send request to CAS.");
+                Console.WriteLine(DateTime.UtcNow + " Received token successfully, now to send request to CAS.");
 
                 // Token received, now send package using token
                 using (var packageClient = new HttpClient())
@@ -110,7 +110,7 @@ namespace AEMInterfaceService.Pages.Controllers
                     var xjo = JObject.Parse(xresponseBody);
 
                     // Return JSON response from CAS
-                    Console.WriteLine(DateTime.Now + " Successfully found invoice: " + casAPQuery.invoiceNumber);
+                    Console.WriteLine(DateTime.UtcNow + " Successfully found invoice: " + casAPQuery.invoiceNumber);
                     return xjo;
                 }
             }
@@ -118,7 +118,7 @@ namespace AEMInterfaceService.Pages.Controllers
             {
                 if (e.HResult == -2146233088)
                 { // Handle error where invoice number / Supplier / Site does not exist
-                    Console.WriteLine(DateTime.Now + " Error in GetTransactionRecords. Invoice: " + casAPQuery.invoiceNumber + ". Supplier: " + casAPQuery.supplierNumber + ". Site: " + casAPQuery.supplierSiteNumber + ". Invoice/Supplier/Site does not exist.");
+                    Console.WriteLine(DateTime.UtcNow + " Error in GetTransactionRecords. Invoice: " + casAPQuery.invoiceNumber + ". Supplier: " + casAPQuery.supplierNumber + ". Site: " + casAPQuery.supplierSiteNumber + ". Invoice/Supplier/Site does not exist.");
                     dynamic errorObject = new JObject();
                     errorObject.invoice_number = casAPQuery.invoiceNumber;
                     errorObject.invoice_status = "Not Found";
@@ -139,7 +139,7 @@ namespace AEMInterfaceService.Pages.Controllers
                 else
                 { // Handle all other errors
                     var errorContent = new StringContent(casAPQuery.ToString(), Encoding.UTF8, "application/json");
-                    Console.WriteLine(DateTime.Now + " Error in GetTransactionRecords. Invoice: " + casAPQuery.invoiceNumber + ". " + e.Message);
+                    Console.WriteLine(DateTime.UtcNow + " Error in GetTransactionRecords. Invoice: " + casAPQuery.invoiceNumber + ". " + e.Message);
                     dynamic errorObject = new JObject();
                     errorObject.invoice_number = casAPQuery.invoiceNumber;
                     errorObject.invoice_status = e.Message;

--- a/AEMInterfaceService/AEMInterfaceService/Pages/Controllers/CASAPTransactionController.cs
+++ b/AEMInterfaceService/AEMInterfaceService/Pages/Controllers/CASAPTransactionController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -37,7 +37,7 @@ namespace AEMInterfaceService.Pages.Controllers
             var headers = re.Headers;
 
             // Get secret information
-            Console.WriteLine(DateTime.Now + " Get Secret information.");
+            Console.WriteLine(DateTime.UtcNow + " Get Secret information.");
             var builder = new ConfigurationBuilder()
                 .AddEnvironmentVariables()
                 .AddUserSecrets<Program>(); // must also define a project guid for secrets in the .cspro – add tag <UserSecretsId> containing a guid
@@ -49,7 +49,7 @@ namespace AEMInterfaceService.Pages.Controllers
             secret = headers["secret"].ToString();
             clientID = headers["clientID"].ToString();
 
-            Console.WriteLine(DateTime.Now + " In RegisterCASAPTransaction");
+            Console.WriteLine(DateTime.UtcNow + " In RegisterCASAPTransaction");
             CASAPTransactionRegistrationReply casregreply = new CASAPTransactionRegistrationReply();
             CASAPTransactionRegistration.getInstance().Add(casAPTransaction);
             //casregreply.RegistrationStatus = "Success";
@@ -65,10 +65,10 @@ namespace AEMInterfaceService.Pages.Controllers
             try
             {
                 // Start by getting token
-                Console.WriteLine(DateTime.Now + " Starting sendTransactionsToCAS (CASAPTransactionController).");
+                Console.WriteLine(DateTime.UtcNow + " Starting sendTransactionsToCAS (CASAPTransactionController).");
 
                 HttpClientHandler handler = new HttpClientHandler();
-                Console.WriteLine(DateTime.Now + " GET: + " + TokenURL);
+                Console.WriteLine(DateTime.UtcNow + " GET: + " + TokenURL);
 
                 HttpClient client = new HttpClient(handler);
 
@@ -79,12 +79,12 @@ namespace AEMInterfaceService.Pages.Controllers
                 var formData = new List<KeyValuePair<string, string>>();
                 formData.Add(new KeyValuePair<string, string>("grant_type", "client_credentials"));
 
-                Console.WriteLine(DateTime.Now + " Add credentials");
+                Console.WriteLine(DateTime.UtcNow + " Add credentials");
                 request.Content = new FormUrlEncodedContent(formData);
                 var response = await client.SendAsync(request);
 
                 response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-                Console.WriteLine(DateTime.Now + " Response Received: " + response.StatusCode);
+                Console.WriteLine(DateTime.UtcNow + " Response Received: " + response.StatusCode);
                 response.EnsureSuccessStatusCode();
 
                 // Put token alone in responseToken
@@ -92,7 +92,7 @@ namespace AEMInterfaceService.Pages.Controllers
                 var jo = JObject.Parse(responseBody);
                 string responseToken = jo["access_token"].ToString();
 
-                Console.WriteLine(DateTime.Now + " Received token successfully, now to send package to CAS.");
+                Console.WriteLine(DateTime.UtcNow + " Received token successfully, now to send package to CAS.");
 
                 // Token received, now send package using token
                 using (var packageClient = new HttpClient())
@@ -101,24 +101,24 @@ namespace AEMInterfaceService.Pages.Controllers
                     var jsonString = JsonConvert.SerializeObject(casAPTransaction);
                     //HttpContent postContent = new StringContent(jsonString, Encoding.UTF8, "application/json");
                     HttpContent postContent = new StringContent(jsonString);
-                    Console.WriteLine(DateTime.Now + " JSON: " + jsonString);
+                    Console.WriteLine(DateTime.UtcNow + " JSON: " + jsonString);
                     HttpResponseMessage packageResult = await packageClient.PostAsync(URL, postContent);
 
-                    Console.WriteLine(DateTime.Now + " This was the result: " + packageResult.StatusCode);
+                    Console.WriteLine(DateTime.UtcNow + " This was the result: " + packageResult.StatusCode);
                     //outputMessage = Convert.ToString(packageResult.StatusCode);
                     outputMessage = Convert.ToString(packageResult.Content.ReadAsStringAsync().Result);
-                    Console.WriteLine(DateTime.Now + " Output Message: " + outputMessage);
+                    Console.WriteLine(DateTime.UtcNow + " Output Message: " + outputMessage);
 
                     if (packageResult.StatusCode == HttpStatusCode.Unauthorized)
                     {
-                        Console.WriteLine(DateTime.Now + " Ruh Roh, there was an error: " + packageResult.StatusCode);
+                        Console.WriteLine(DateTime.UtcNow + " Ruh Roh, there was an error: " + packageResult.StatusCode);
                     }
                 }
             }
             catch (Exception e)
             {
                 var errorContent = new StringContent(casAPTransaction.ToString(), Encoding.UTF8, "application/json");
-                Console.WriteLine(DateTime.Now + " Error in RegisterCASAPTransaction. Invoice: " + casAPTransaction.invoiceNumber);
+                Console.WriteLine(DateTime.UtcNow + " Error in RegisterCASAPTransaction. Invoice: " + casAPTransaction.invoiceNumber);
                 dynamic errorObject = new JObject();
                 errorObject.invoice_number = null;
                 errorObject.CAS_Returned_Messages = "Generic Error: " + e.Message;
@@ -126,7 +126,7 @@ namespace AEMInterfaceService.Pages.Controllers
             }
 
             var xjo = JObject.Parse(outputMessage);
-            Console.WriteLine(DateTime.Now + " Successfully sent invoice: " + casAPTransaction.invoiceNumber);
+            Console.WriteLine(DateTime.UtcNow + " Successfully sent invoice: " + casAPTransaction.invoiceNumber);
             return xjo;
         }
 
@@ -135,7 +135,7 @@ namespace AEMInterfaceService.Pages.Controllers
         {
             try
             {
-                Console.WriteLine(DateTime.Now + " In InsertCASAPTransaction");
+                Console.WriteLine(DateTime.UtcNow + " In InsertCASAPTransaction");
                 CASAPTransactionRegistrationReply casregreply = new CASAPTransactionRegistrationReply();
                 CASAPTransactionRegistration.getInstance().Add(casAPTransaction);
                 casregreply.RegistrationStatus = "Success";
@@ -148,7 +148,7 @@ namespace AEMInterfaceService.Pages.Controllers
             }
             catch(Exception e)
             {
-                Console.WriteLine(DateTime.Now + " Error in InsertCASAPTransaction. " + e.ToString());
+                Console.WriteLine(DateTime.UtcNow + " Error in InsertCASAPTransaction. " + e.ToString());
                 return StatusCode(e.HResult);
             }
 

--- a/AEMInterfaceService/AEMInterfaceService/Pages/Controllers/CornetTransactionController.cs
+++ b/AEMInterfaceService/AEMInterfaceService/Pages/Controllers/CornetTransactionController.cs
@@ -40,56 +40,38 @@ namespace AEMInterfaceService.Pages.Controllers
         [HttpPost]
         public CornetTransactionRegistrationReply RegisterCornetTransaction(CornetTransaction cornetTransaction)
         {
-            Console.WriteLine(DateTime.Now + " In RegisterCornetTransaction");
+            Console.WriteLine(DateTime.UtcNow + " In RegisterCornetTransaction");
             CornetTransactionRegistrationReply cornetregreply = new CornetTransactionRegistrationReply();
             CornetTransactionRegistration.getInstance().Add(cornetTransaction);
-            Console.WriteLine(DateTime.Now + " Received data from Cornet");
+            Console.WriteLine(DateTime.UtcNow + " Received data from Cornet");
 
             var t = Task.Run(() => CallDynamicsWithCornetData(_configuration, cornetTransaction));
             t.Wait();
-            Console.WriteLine(DateTime.Now + " Sent data to Dynamics");
+            Console.WriteLine(DateTime.UtcNow + " Sent data to Dynamics");
 
             if (t.Result.Contains("Cornet Notification "))
             {
                 cornetregreply.ResponseCode = "200";
                 cornetregreply.ResponseMessage = "Success";
-                Console.WriteLine(DateTime.Now + " Response Success");
+                Console.WriteLine(DateTime.UtcNow + " Response Success");
             }
             else
             {
-                //JObject tempJson = JObject.Parse(t.Result);
-                //CornetDynamicsReply replyJson = new CornetDynamicsReply();
-
-                //if (t.IsCompletedSuccessfully == true)
-                //{
-                //    cornetregreply.ResponseMessage = "Success";
-                //    cornetregreply.ResponseCode = null;// t.Result;
-                //    Console.WriteLine(DateTime.Now + " Response Success");
-                //}
-                //else
-                //{
                 cornetregreply.ResponseMessage = "Failure";
                 cornetregreply.ResponseCode = t.Result;
-                Console.WriteLine(DateTime.Now + " Response Fail");
+                Console.WriteLine(DateTime.UtcNow + " Response Fail");
                 //}
             }
+            
 
-            // Responses as follows:
-            // 200 - Status OK - Automatically Done
-            // 400 - Bad Request (Malformed JSON) - Automatically Done
-            // 500 - Internal Server Error (Something wrong on our end)
-            // 201 - If anything is being created on our end based on the notification sent
-            // This next line is just a sample of how to do it:
-            //this.HttpContext.Response.StatusCode = 444;
-
-            Console.WriteLine(DateTime.Now + " Exit RegisterCornetTransaction");
+            Console.WriteLine(DateTime.UtcNow + " Exit RegisterCornetTransaction");
             return cornetregreply;
 
         }
 
         private static async Task<string> CallDynamicsWithCornetData(IConfiguration configuration, CornetTransaction model)
         {
-            Console.WriteLine(DateTime.Now + " In CallDynamicsWithCornetData");
+            Console.WriteLine(DateTime.UtcNow + " In CallDynamicsWithCornetData");
             HttpClient httpClient = null;
             try
             {
@@ -101,9 +83,9 @@ namespace AEMInterfaceService.Pages.Controllers
 
                 // Get results into the tuple
                 var endpointAction = "vsd_CreateCORNETNotifications";
-                Console.WriteLine(DateTime.Now + " Set endpoint " + endpointAction);
+                Console.WriteLine(DateTime.UtcNow + " Set endpoint " + endpointAction);
                 var tuple = await GetDynamicsHttpClientNew(configuration, cornetJson, endpointAction);
-                Console.WriteLine(DateTime.Now + " Got result from Dynamics");
+                Console.WriteLine(DateTime.UtcNow + " Got result from Dynamics");
 
                 string tempResult = tuple.Item1.ToString();
 
@@ -126,7 +108,7 @@ namespace AEMInterfaceService.Pages.Controllers
                     dynamicsResponse.odatacontext = dynamicsResponse.Result;
                 }
 
-                Console.WriteLine(DateTime.Now + " Return results from Dynamics");
+                Console.WriteLine(DateTime.UtcNow + " Return results from Dynamics");
                 return dynamicsResponse.odatacontext;
 
             }
@@ -139,12 +121,12 @@ namespace AEMInterfaceService.Pages.Controllers
 
         static async Task<Tuple<int, HttpResponseMessage, string>> GetDynamicsHttpClientNew(IConfiguration configuration, String model, String endPointName)
         {
-            Console.WriteLine(DateTime.Now + " In GetDynamicsHttpClientNew");
+            Console.WriteLine(DateTime.UtcNow + " In GetDynamicsHttpClientNew");
             var builder = new ConfigurationBuilder()
                 .AddEnvironmentVariables()
                 .AddUserSecrets<Program>();
             var Configuration = builder.Build();
-            Console.WriteLine(DateTime.Now + " Build Configuration");
+            Console.WriteLine(DateTime.UtcNow + " Build Configuration");
 
             // Bind Dynamics configuration
             var dynamicsOptions =
@@ -157,7 +139,7 @@ namespace AEMInterfaceService.Pages.Controllers
                 throw new Exception("Configuration setting for DynamicsApiEndpointUrl is blank.");
             }
 
-            Console.WriteLine(DateTime.Now + " Variables have been set");
+            Console.WriteLine(DateTime.UtcNow + " Variables have been set");
 
             try
             {
@@ -172,7 +154,7 @@ namespace AEMInterfaceService.Pages.Controllers
 
                 // Acquire token
                 string token = await tokenProvider.AcquireToken();
-                Console.WriteLine(DateTime.Now + " Got a token");
+                Console.WriteLine(DateTime.UtcNow + " Got a token");
 
                 // Call Dynamics
                 using var client = new HttpClient();
@@ -182,29 +164,29 @@ namespace AEMInterfaceService.Pages.Controllers
                 client.DefaultRequestHeaders.Add("Accept", "application/json");
 
                 string url = dynamicsOdataUri + endPointName;
-                Console.WriteLine(DateTime.Now + " Set full URL to speak to Dynamics: " + url);
+                Console.WriteLine(DateTime.UtcNow + " Set full URL to speak to Dynamics: " + url);
 
                 HttpRequestMessage _httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
                 _httpRequest.Content = new StringContent(model, Encoding.UTF8, "application/json");
-                Console.WriteLine(DateTime.Now + " Got HTTP Request ready");
+                Console.WriteLine(DateTime.UtcNow + " Got HTTP Request ready");
 
                 var _httpResponse = await client.SendAsync(_httpRequest);
                 HttpStatusCode _statusCode = _httpResponse.StatusCode;
 
                 var _responseString = _httpResponse.ToString();
-                Console.WriteLine(DateTime.Now + " Got HTTP Response");
+                Console.WriteLine(DateTime.UtcNow + " Got HTTP Response");
                 var _responseContent = await _httpResponse.Content.ReadAsStringAsync();
 
-                Console.Out.WriteLine(DateTime.Now + " model: " + model);
-                Console.Out.WriteLine(DateTime.Now + " responseString: " + _responseString);
-                Console.Out.WriteLine(DateTime.Now + " responseContent: " + _responseContent);
+                Console.Out.WriteLine(DateTime.UtcNow + " model: " + model);
+                Console.Out.WriteLine(DateTime.UtcNow + " responseString: " + _responseString);
+                Console.Out.WriteLine(DateTime.UtcNow + " responseContent: " + _responseContent);
 
-                Console.WriteLine(DateTime.Now + " Exit GetDynamicsHttpClientNew");
+                Console.WriteLine(DateTime.UtcNow + " Exit GetDynamicsHttpClientNew");
                 return new Tuple<int, HttpResponseMessage, string>((int)_statusCode, _httpResponse, _responseContent);
             }
             catch (Exception e)
             {
-                Console.WriteLine(DateTime.Now + " Error in GetDynamicsHttpClientNew: " + e.Message);
+                Console.WriteLine(DateTime.UtcNow + " Error in GetDynamicsHttpClientNew: " + e.Message);
                 return new Tuple<int, HttpResponseMessage, string>(100, null, "Error: " + e.Message);
             }
         }
@@ -214,7 +196,7 @@ namespace AEMInterfaceService.Pages.Controllers
         {
             try
             {
-                Console.WriteLine(DateTime.Now + " In InsertCornetTransaction");
+                Console.WriteLine(DateTime.UtcNow + " In InsertCornetTransaction");
                 CornetTransactionRegistrationReply casregreply = new CornetTransactionRegistrationReply();
                 CornetTransactionRegistration.getInstance().Add(cornetTransaction);
                 casregreply.ResponseMessage = "Success";
@@ -223,7 +205,7 @@ namespace AEMInterfaceService.Pages.Controllers
             }
             catch (Exception e)
             {
-                Console.WriteLine(DateTime.Now + " Error in InsertCornetTransaction. " + e.ToString());
+                Console.WriteLine(DateTime.UtcNow + " Error in InsertCornetTransaction. " + e.ToString());
                 return StatusCode(e.HResult);
             }
 

--- a/AEMInterfaceService/AEMInterfaceService/Pages/Models/CornetTransaction.cs
+++ b/AEMInterfaceService/AEMInterfaceService/Pages/Models/CornetTransaction.cs
@@ -32,9 +32,9 @@ namespace AEMInterfaceService.Pages.Models
             set { MessageEventTypeCD = value; }
         }
 
-        DateTime EventDTM;
+        DateTimeOffset EventDTM;
         [Required]
-        public DateTime event_dtm
+        public DateTimeOffset event_dtm
         {
             get { return EventDTM; }
             set { EventDTM = value; }

--- a/CASInterfaceService/CASInterfaceService/Dockerfile
+++ b/CASInterfaceService/CASInterfaceService/Dockerfile
@@ -29,6 +29,9 @@ FROM base AS final
 WORKDIR /app
 RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
 
+# package is updated to include the new America/Vancouver permanent-offset rule.
+RUN apk add --no-cache tzdata
+
 # Accept build args and export as environment variables
 ARG BUILD_ID
 ARG BUILD_VERSION

--- a/CASInterfaceService/CASInterfaceService/Pages/Models/CornetTransaction.cs
+++ b/CASInterfaceService/CASInterfaceService/Pages/Models/CornetTransaction.cs
@@ -31,9 +31,9 @@ namespace CASInterfaceService.Pages.Models
             set { MessageEventTypeCD = value; }
         }
 
-        DateTime EventDTM;
+        DateTimeOffset EventDTM;
         [Required]
-        public DateTime event_dtm
+        public DateTimeOffset event_dtm
         {
             get { return EventDTM; }
             set { EventDTM = value; }

--- a/CornetInterfaceService/CornetInterfaceService/Pages/Controllers/CASAPRetrieveController.cs
+++ b/CornetInterfaceService/CornetInterfaceService/Pages/Controllers/CASAPRetrieveController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -50,14 +50,14 @@ namespace CASInterfaceService.Pages.Controllers
             secret = headers["secret"].ToString();
             clientID = headers["clientID"].ToString();
 
-            Console.WriteLine(DateTime.Now + " In RegisterCASAPTransaction");
+            Console.WriteLine(DateTime.UtcNow + " In RegisterCASAPTransaction");
             CASAPTransactionRegistrationReply casregreply = new CASAPTransactionRegistrationReply();
             CASAPQueryRegistration.getInstance().Add(casAPQuery);
 
             try
             {
                 // Start by getting token
-                Console.WriteLine(DateTime.Now + " Starting sendTransactionsToCAS (CASAPRetreiveController).");
+                Console.WriteLine(DateTime.UtcNow + " Starting sendTransactionsToCAS (CASAPRetreiveController).");
 
                 // Get secret information
                 Console.WriteLine("Get Secret information.");
@@ -69,7 +69,7 @@ namespace CASInterfaceService.Pages.Controllers
                 TokenURL = Configuration["CAS_API_URI"] + "oauth/token"; // CAS AP Token URL
 
                 HttpClientHandler handler = new HttpClientHandler();
-                Console.WriteLine(DateTime.Now + " GET: + " + TokenURL);
+                Console.WriteLine(DateTime.UtcNow + " GET: + " + TokenURL);
 
                 HttpClient client = new HttpClient(handler);
 
@@ -80,7 +80,7 @@ namespace CASInterfaceService.Pages.Controllers
                 var formData = new List<KeyValuePair<string, string>>();
                 formData.Add(new KeyValuePair<string, string>("grant_type", "client_credentials"));
 
-                Console.WriteLine(DateTime.Now + " Add credentials");
+                Console.WriteLine(DateTime.UtcNow + " Add credentials");
                 request.Content = new FormUrlEncodedContent(formData);
                 var response = await client.SendAsync(request);
 
@@ -93,7 +93,7 @@ namespace CASInterfaceService.Pages.Controllers
                 var jo = JObject.Parse(responseBody);
                 string responseToken = jo["access_token"].ToString();
 
-                Console.WriteLine(DateTime.Now + " Received token successfully, now to send request to CAS.");
+                Console.WriteLine(DateTime.UtcNow + " Received token successfully, now to send request to CAS.");
 
                 // Token received, now send package using token
                 using (var packageClient = new HttpClient())
@@ -110,7 +110,7 @@ namespace CASInterfaceService.Pages.Controllers
                     var xjo = JObject.Parse(xresponseBody);
 
                     // Return JSON response from CAS
-                    Console.WriteLine(DateTime.Now + " Successfully found invoice: " + casAPQuery.invoiceNumber);
+                    Console.WriteLine(DateTime.UtcNow + " Successfully found invoice: " + casAPQuery.invoiceNumber);
                     return xjo;
                 }
             }
@@ -118,7 +118,7 @@ namespace CASInterfaceService.Pages.Controllers
             {
                 if (e.HResult == -2146233088)
                 { // Handle error where invoice number / Supplier / Site does not exist
-                    Console.WriteLine(DateTime.Now + " Error in GetTransactionRecords. Invoice: " + casAPQuery.invoiceNumber + ". Supplier: " + casAPQuery.supplierNumber + ". Site: " + casAPQuery.supplierSiteNumber + ". Invoice/Supplier/Site does not exist.");
+                    Console.WriteLine(DateTime.UtcNow + " Error in GetTransactionRecords. Invoice: " + casAPQuery.invoiceNumber + ". Supplier: " + casAPQuery.supplierNumber + ". Site: " + casAPQuery.supplierSiteNumber + ". Invoice/Supplier/Site does not exist.");
                     dynamic errorObject = new JObject();
                     errorObject.invoice_number = casAPQuery.invoiceNumber;
                     errorObject.invoice_status = "Not Found";
@@ -139,7 +139,7 @@ namespace CASInterfaceService.Pages.Controllers
                 else
                 { // Handle all other errors
                     var errorContent = new StringContent(casAPQuery.ToString(), Encoding.UTF8, "application/json");
-                    Console.WriteLine(DateTime.Now + " Error in GetTransactionRecords. Invoice: " + casAPQuery.invoiceNumber + ". " + e.Message);
+                    Console.WriteLine(DateTime.UtcNow + " Error in GetTransactionRecords. Invoice: " + casAPQuery.invoiceNumber + ". " + e.Message);
                     dynamic errorObject = new JObject();
                     errorObject.invoice_number = casAPQuery.invoiceNumber;
                     errorObject.invoice_status = e.Message;

--- a/CornetInterfaceService/CornetInterfaceService/Pages/Controllers/CASAPTransactionController.cs
+++ b/CornetInterfaceService/CornetInterfaceService/Pages/Controllers/CASAPTransactionController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -37,7 +37,7 @@ namespace CASInterfaceService.Pages.Controllers
             var headers = re.Headers;
 
             // Get secret information
-            Console.WriteLine(DateTime.Now + " Get Secret information.");
+            Console.WriteLine(DateTime.UtcNow + " Get Secret information.");
             var builder = new ConfigurationBuilder()
                 .AddEnvironmentVariables()
                 .AddUserSecrets<Program>(); // must also define a project guid for secrets in the .cspro – add tag <UserSecretsId> containing a guid
@@ -49,7 +49,7 @@ namespace CASInterfaceService.Pages.Controllers
             secret = headers["secret"].ToString();
             clientID = headers["clientID"].ToString();
 
-            Console.WriteLine(DateTime.Now + " In RegisterCASAPTransaction");
+            Console.WriteLine(DateTime.UtcNow + " In RegisterCASAPTransaction");
             CASAPTransactionRegistrationReply casregreply = new CASAPTransactionRegistrationReply();
             CASAPTransactionRegistration.getInstance().Add(casAPTransaction);
             //casregreply.RegistrationStatus = "Success";
@@ -65,10 +65,10 @@ namespace CASInterfaceService.Pages.Controllers
             try
             {
                 // Start by getting token
-                Console.WriteLine(DateTime.Now + " Starting sendTransactionsToCAS (CASAPTransactionController).");
+                Console.WriteLine(DateTime.UtcNow + " Starting sendTransactionsToCAS (CASAPTransactionController).");
 
                 HttpClientHandler handler = new HttpClientHandler();
-                Console.WriteLine(DateTime.Now + " GET: + " + TokenURL);
+                Console.WriteLine(DateTime.UtcNow + " GET: + " + TokenURL);
 
                 HttpClient client = new HttpClient(handler);
 
@@ -79,12 +79,12 @@ namespace CASInterfaceService.Pages.Controllers
                 var formData = new List<KeyValuePair<string, string>>();
                 formData.Add(new KeyValuePair<string, string>("grant_type", "client_credentials"));
 
-                Console.WriteLine(DateTime.Now + " Add credentials");
+                Console.WriteLine(DateTime.UtcNow + " Add credentials");
                 request.Content = new FormUrlEncodedContent(formData);
                 var response = await client.SendAsync(request);
 
                 response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-                Console.WriteLine(DateTime.Now + " Response Received: " + response.StatusCode);
+                Console.WriteLine(DateTime.UtcNow + " Response Received: " + response.StatusCode);
                 response.EnsureSuccessStatusCode();
 
                 // Put token alone in responseToken
@@ -92,7 +92,7 @@ namespace CASInterfaceService.Pages.Controllers
                 var jo = JObject.Parse(responseBody);
                 string responseToken = jo["access_token"].ToString();
 
-                Console.WriteLine(DateTime.Now + " Received token successfully, now to send package to CAS.");
+                Console.WriteLine(DateTime.UtcNow + " Received token successfully, now to send package to CAS.");
 
                 // Token received, now send package using token
                 using (var packageClient = new HttpClient())
@@ -101,24 +101,24 @@ namespace CASInterfaceService.Pages.Controllers
                     var jsonString = JsonConvert.SerializeObject(casAPTransaction);
                     //HttpContent postContent = new StringContent(jsonString, Encoding.UTF8, "application/json");
                     HttpContent postContent = new StringContent(jsonString);
-                    Console.WriteLine(DateTime.Now + " JSON: " + jsonString);
+                    Console.WriteLine(DateTime.UtcNow + " JSON: " + jsonString);
                     HttpResponseMessage packageResult = await packageClient.PostAsync(URL, postContent);
 
-                    Console.WriteLine(DateTime.Now + " This was the result: " + packageResult.StatusCode);
+                    Console.WriteLine(DateTime.UtcNow + " This was the result: " + packageResult.StatusCode);
                     //outputMessage = Convert.ToString(packageResult.StatusCode);
                     outputMessage = Convert.ToString(packageResult.Content.ReadAsStringAsync().Result);
-                    Console.WriteLine(DateTime.Now + " Output Message: " + outputMessage);
+                    Console.WriteLine(DateTime.UtcNow + " Output Message: " + outputMessage);
 
                     if (packageResult.StatusCode == HttpStatusCode.Unauthorized)
                     {
-                        Console.WriteLine(DateTime.Now + " Ruh Roh, there was an error: " + packageResult.StatusCode);
+                        Console.WriteLine(DateTime.UtcNow + " Ruh Roh, there was an error: " + packageResult.StatusCode);
                     }
                 }
             }
             catch (Exception e)
             {
                 var errorContent = new StringContent(casAPTransaction.ToString(), Encoding.UTF8, "application/json");
-                Console.WriteLine(DateTime.Now + " Error in RegisterCASAPTransaction. Invoice: " + casAPTransaction.invoiceNumber);
+                Console.WriteLine(DateTime.UtcNow + " Error in RegisterCASAPTransaction. Invoice: " + casAPTransaction.invoiceNumber);
                 dynamic errorObject = new JObject();
                 errorObject.invoice_number = null;
                 errorObject.CAS_Returned_Messages = "Generic Error: " + e.Message;
@@ -126,7 +126,7 @@ namespace CASInterfaceService.Pages.Controllers
             }
 
             var xjo = JObject.Parse(outputMessage);
-            Console.WriteLine(DateTime.Now + " Successfully sent invoice: " + casAPTransaction.invoiceNumber);
+            Console.WriteLine(DateTime.UtcNow + " Successfully sent invoice: " + casAPTransaction.invoiceNumber);
             return xjo;
         }
 
@@ -135,7 +135,7 @@ namespace CASInterfaceService.Pages.Controllers
         {
             try
             {
-                Console.WriteLine(DateTime.Now + " In InsertCASAPTransaction");
+                Console.WriteLine(DateTime.UtcNow + " In InsertCASAPTransaction");
                 CASAPTransactionRegistrationReply casregreply = new CASAPTransactionRegistrationReply();
                 CASAPTransactionRegistration.getInstance().Add(casAPTransaction);
                 casregreply.RegistrationStatus = "Success";
@@ -148,7 +148,7 @@ namespace CASInterfaceService.Pages.Controllers
             }
             catch(Exception e)
             {
-                Console.WriteLine(DateTime.Now + " Error in InsertCASAPTransaction. " + e.ToString());
+                Console.WriteLine(DateTime.UtcNow + " Error in InsertCASAPTransaction. " + e.ToString());
                 return StatusCode(e.HResult);
             }
 

--- a/CornetInterfaceService/CornetInterfaceService/Pages/Controllers/CornetTransactionController.cs
+++ b/CornetInterfaceService/CornetInterfaceService/Pages/Controllers/CornetTransactionController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -40,38 +40,27 @@ namespace CASInterfaceService.Pages.Controllers
         [HttpPost]
         public CornetTransactionRegistrationReply RegisterCornetTransaction(CornetTransaction cornetTransaction)
         {
-            Console.WriteLine(DateTime.Now + " In RegisterCornetTransaction");
+            Console.WriteLine(DateTime.UtcNow + " In RegisterCornetTransaction");
             CornetTransactionRegistrationReply cornetregreply = new CornetTransactionRegistrationReply();
             CornetTransactionRegistration.getInstance().Add(cornetTransaction);
-            Console.WriteLine(DateTime.Now + " Received data from Cornet");
+            Console.WriteLine(DateTime.UtcNow + " Received data from Cornet");
             try
             {
                 var t = Task.Run(() => CallDynamicsWithCornetData(_configuration, cornetTransaction));
                 t.Wait();
-                Console.WriteLine(DateTime.Now + " Sent data to Dynamics");
+                Console.WriteLine(DateTime.UtcNow + " Sent data to Dynamics");
 
                 if (t.Result.Contains("Cornet Notification "))
                 {
                     cornetregreply.ResponseCode = "200";
                     cornetregreply.ResponseMessage = "Success";
-                    Console.WriteLine(DateTime.Now + " Response Success");
+                    Console.WriteLine(DateTime.UtcNow + " Response Success");
                 }
                 else
-                {
-                    //JObject tempJson = JObject.Parse(t.Result);
-                    //CornetDynamicsReply replyJson = new CornetDynamicsReply();
-
-                    //if (t.IsCompletedSuccessfully == true)
-                    //{
-                    //    cornetregreply.ResponseMessage = "Success";
-                    //    cornetregreply.ResponseCode = null;// t.Result;
-                    //    Console.WriteLine(DateTime.Now + " Response Success");
-                    //}
-                    //else
-                    //{
+                {                    
                     cornetregreply.ResponseMessage = "Failure";
                     cornetregreply.ResponseCode = t.Result;
-                    Console.WriteLine(DateTime.Now + " Response Fail");
+                    Console.WriteLine(DateTime.UtcNow + " Response Fail");
                     //}
                 }
 
@@ -83,7 +72,7 @@ namespace CASInterfaceService.Pages.Controllers
                 // This next line is just a sample of how to do it:
                 //this.HttpContext.Response.StatusCode = 444;
 
-                Console.WriteLine(DateTime.Now + " Exit RegisterCornetTransaction");
+                Console.WriteLine(DateTime.UtcNow + " Exit RegisterCornetTransaction");
                 return cornetregreply;
 
             }
@@ -98,7 +87,7 @@ namespace CASInterfaceService.Pages.Controllers
 
         private static async Task<string> CallDynamicsWithCornetData(IConfiguration configuration, CornetTransaction model)
         {
-            Console.WriteLine(DateTime.Now + " In CallDynamicsWithCornetData");
+            Console.WriteLine(DateTime.UtcNow + " In CallDynamicsWithCornetData");
             HttpClient httpClient = null;
             try
             {
@@ -110,9 +99,9 @@ namespace CASInterfaceService.Pages.Controllers
 
                 // Get results into the tuple
                 var endpointAction = "vsd_CreateCORNETNotifications";
-                Console.WriteLine(DateTime.Now + " Set endpoint " + endpointAction);
+                Console.WriteLine(DateTime.UtcNow + " Set endpoint " + endpointAction);
                 var tuple = await GetDynamicsHttpClientNew(configuration, cornetJson, endpointAction);
-                Console.WriteLine(DateTime.Now + " Got result from Dynamics");
+                Console.WriteLine(DateTime.UtcNow + " Got result from Dynamics");
 
                 string tempResult = tuple.Item1.ToString();
 
@@ -135,7 +124,7 @@ namespace CASInterfaceService.Pages.Controllers
                     dynamicsResponse.odatacontext = dynamicsResponse.Result;
                 }
 
-                Console.WriteLine(DateTime.Now + " Return results from Dynamics");
+                Console.WriteLine(DateTime.UtcNow + " Return results from Dynamics");
                 return dynamicsResponse.odatacontext;
 
             }
@@ -148,12 +137,12 @@ namespace CASInterfaceService.Pages.Controllers
 
         static async Task<Tuple<int, HttpResponseMessage, string>> GetDynamicsHttpClientNew(IConfiguration configuration, String model, String endPointName)
         {
-            Console.WriteLine(DateTime.Now + " In GetDynamicsHttpClientNew");
+            Console.WriteLine(DateTime.UtcNow + " In GetDynamicsHttpClientNew");
             var builder = new ConfigurationBuilder()
                 .AddEnvironmentVariables()
                 .AddUserSecrets<Program>();
             var Configuration = builder.Build();
-            Console.WriteLine(DateTime.Now + " Build Configuration");
+            Console.WriteLine(DateTime.UtcNow + " Build Configuration");
 
             // Bind Dynamics configuration
             var dynamicsOptions =
@@ -166,7 +155,7 @@ namespace CASInterfaceService.Pages.Controllers
                 throw new Exception("Configuration setting for DynamicsApiEndpointUrl is blank.");
             }
 
-            Console.WriteLine(DateTime.Now + " Variables have been set");
+            Console.WriteLine(DateTime.UtcNow + " Variables have been set");
 
             try
             {
@@ -181,7 +170,7 @@ namespace CASInterfaceService.Pages.Controllers
 
                 // Acquire token
                 string token = await tokenProvider.AcquireToken();
-                Console.WriteLine(DateTime.Now + " Got a token");
+                Console.WriteLine(DateTime.UtcNow + " Got a token");
 
                 // Call Dynamics
                 using var client = new HttpClient();
@@ -191,29 +180,29 @@ namespace CASInterfaceService.Pages.Controllers
                 client.DefaultRequestHeaders.Add("Accept", "application/json");
 
                 string url = dynamicsOdataUri + endPointName;
-                Console.WriteLine(DateTime.Now + " Set full URL to speak to Dynamics: " + url);
+                Console.WriteLine(DateTime.UtcNow + " Set full URL to speak to Dynamics: " + url);
 
                 HttpRequestMessage _httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
                 _httpRequest.Content = new StringContent(model, Encoding.UTF8, "application/json");
-                Console.WriteLine(DateTime.Now + " Got HTTP Request ready");
+                Console.WriteLine(DateTime.UtcNow + " Got HTTP Request ready");
 
                 var _httpResponse = await client.SendAsync(_httpRequest);
                 HttpStatusCode _statusCode = _httpResponse.StatusCode;
 
                 var _responseString = _httpResponse.ToString();
-                Console.WriteLine(DateTime.Now + " Got HTTP Response");
+                Console.WriteLine(DateTime.UtcNow + " Got HTTP Response");
                 var _responseContent = await _httpResponse.Content.ReadAsStringAsync();
 
-                Console.Out.WriteLine(DateTime.Now + " model: " + model);
-                Console.Out.WriteLine(DateTime.Now + " responseString: " + _responseString);
-                Console.Out.WriteLine(DateTime.Now + " responseContent: " + _responseContent);
+                Console.Out.WriteLine(DateTime.UtcNow + " model: " + model);
+                Console.Out.WriteLine(DateTime.UtcNow + " responseString: " + _responseString);
+                Console.Out.WriteLine(DateTime.UtcNow + " responseContent: " + _responseContent);
 
-                Console.WriteLine(DateTime.Now + " Exit GetDynamicsHttpClientNew");
+                Console.WriteLine(DateTime.UtcNow + " Exit GetDynamicsHttpClientNew");
                 return new Tuple<int, HttpResponseMessage, string>((int)_statusCode, _httpResponse, _responseContent);
             }
             catch (Exception e)
             {
-                Console.WriteLine(DateTime.Now + " Error in GetDynamicsHttpClientNew: " + e.Message);
+                Console.WriteLine(DateTime.UtcNow + " Error in GetDynamicsHttpClientNew: " + e.Message);
                 return new Tuple<int, HttpResponseMessage, string>(100, null, "Error: " + e.Message);
             }
         }
@@ -223,7 +212,7 @@ namespace CASInterfaceService.Pages.Controllers
         {
             try
             {
-                Console.WriteLine(DateTime.Now + " In InsertCornetTransaction");
+                Console.WriteLine(DateTime.UtcNow + " In InsertCornetTransaction");
                 CornetTransactionRegistrationReply casregreply = new CornetTransactionRegistrationReply();
                 CornetTransactionRegistration.getInstance().Add(cornetTransaction);
                 casregreply.ResponseMessage = "Success";
@@ -232,7 +221,7 @@ namespace CASInterfaceService.Pages.Controllers
             }
             catch (Exception e)
             {
-                Console.WriteLine(DateTime.Now + " Error in InsertCornetTransaction. " + e.ToString());
+                Console.WriteLine(DateTime.UtcNow + " Error in InsertCornetTransaction. " + e.ToString());
                 return StatusCode(e.HResult);
             }
 

--- a/CornetInterfaceService/CornetInterfaceService/Pages/Models/CornetTransaction.cs
+++ b/CornetInterfaceService/CornetInterfaceService/Pages/Models/CornetTransaction.cs
@@ -31,9 +31,9 @@ namespace CASInterfaceService.Pages.Models
             set { MessageEventTypeCD = value; }
         }
 
-        DateTime EventDTM;
+        DateTimeOffset EventDTM;
         [Required]
-        public DateTime event_dtm
+        public DateTimeOffset event_dtm
         {
             get { return EventDTM; }
             set { EventDTM = value; }

--- a/CornetInterfaceService/Dockerfile
+++ b/CornetInterfaceService/Dockerfile
@@ -29,6 +29,9 @@ FROM base AS final
 WORKDIR /app
 RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
 
+# package is updated to include the new America/Vancouver permanent-offset rule.
+RUN apk add --no-cache tzdata
+
 # build args export to environment
 ARG BUILD_ID
 ARG BUILD_VERSION

--- a/DST-SCAN-REPORT.md
+++ b/DST-SCAN-REPORT.md
@@ -1,0 +1,160 @@
+# DST Impact Scan — COAST OpenShift Applications
+
+**Scan date:** 2026-08-11  
+**Scope:** All services in `coast-utilities` mono-repo  
+**Services reviewed:** AEMInterfaceService · CASInterfaceService · CornetInterfaceService · job-scheduling · Shared.Database
+
+---
+
+## Executive Summary
+
+All four COAST services run in **UTC-only containers** (Alpine/Debian Linux, no `TZ` environment variable set). This baseline eliminates the most common class of DST bugs. Three confirmed issues were found and remediated. One residual risk requires an operator action outside this repository.
+
+---
+
+## Scan Areas Covered
+
+| Area                                    | Reviewed               |
+| --------------------------------------- | ---------------------- |
+| Application C# source code              | ✅                     |
+| OpenShift deploy templates (JSON)       | ✅                     |
+| Dockerfiles                             | ✅                     |
+| GitHub Actions CI/CD workflows          | ✅                     |
+| `appsettings.json` / environment config | ✅                     |
+| NuGet package manifest (`.csproj`)      | ✅                     |
+| Shared.Database token caching           | ✅                     |
+| OpenShift CronJob schedule              | ✅ (see Residual Risk) |
+
+---
+
+## Findings and Remediations
+
+### FINDING-01 — HIGH — `CornetTransaction.event_dtm` typed as `DateTime` ✅ FIXED
+
+**Files affected (before fix):**
+
+- `AEMInterfaceService/AEMInterfaceService/Pages/Models/CornetTransaction.cs`
+- `CASInterfaceService/CASInterfaceService/Pages/Models/CornetTransaction.cs`
+- `CornetInterfaceService/CornetInterfaceService/Pages/Models/CornetTransaction.cs`
+
+**Root cause:**  
+The `event_dtm` field was declared as `DateTime` (timezone-unaware). When a caller sends a timestamp without an offset (e.g., `"2024-03-10T02:30:00"`), the JSON deserializer sets `DateTimeKind.Unspecified`. The subsequent assignment to `CornetDynamicsModel.EventDate` (which is `DateTimeOffset`) implicitly applied the process's local UTC offset — masking the ambiguity. During a DST transition the "spring forward" hour does not exist and the "fall back" hour is ambiguous, making an `Unspecified` kind incorrect.
+
+**Remediation applied:**  
+Changed `DateTime EventDTM` → `DateTimeOffset EventDTM` (and the public property type) in all three `CornetTransaction.cs` files. `DateTimeOffset` always carries an explicit UTC offset, making the DST ambiguity impossible to introduce silently. The outbound `CornetDynamicsModel.EventDate` was already `DateTimeOffset`; the intermediate model now matches it.
+
+**Build verification:** All four projects built with 0 errors after the change.
+
+---
+
+### FINDING-02 — MEDIUM — Alpine images lacked `tzdata` package ✅ FIXED
+
+**Files affected (before fix):**
+
+- `AEMInterfaceService/AEMInterfaceService/Dockerfile`
+- `CASInterfaceService/CASInterfaceService/Dockerfile`
+- `CornetInterfaceService/Dockerfile`
+
+**Root cause:**  
+`mcr.microsoft.com/dotnet/aspnet:10.0-alpine` does not include the `tzdata` package. Any future call to `TimeZoneInfo.FindSystemTimeZoneById("America/Vancouver")` or similar IANA-name lookups would throw `TimeZoneNotFoundException` at runtime. The current code does not use named timezone IDs, but this is a latent risk whenever timezone conversion logic is added.
+
+`job-scheduling` uses `mcr.microsoft.com/dotnet/runtime:10.0` (Debian-based), which ships `tzdata` by default — no change needed there.
+
+**Remediation applied:**  
+Added `RUN apk add --no-cache tzdata` to all three Alpine-based Dockerfiles immediately after the `adduser` step in the final stage.
+
+---
+
+### FINDING-03 — LOW — `DateTime.Now` used for console log timestamps ✅ FIXED
+
+**Files affected (before fix):**
+
+- `AEMInterfaceService/.../AEMTransactionController.cs` (28 occurrences)
+- `AEMInterfaceService/.../CASAPRetrieveController.cs`
+- `AEMInterfaceService/.../CASAPTransactionController.cs`
+- `AEMInterfaceService/.../CornetTransactionController.cs`
+- `CornetInterfaceService/.../CASAPRetrieveController.cs`
+- `CornetInterfaceService/.../CASAPTransactionController.cs`
+- `CornetInterfaceService/.../CornetTransactionController.cs`
+
+**Root cause:**  
+`DateTime.Now` returns local system time. Because no `TZ` environment variable is set on these containers, their local time is already UTC and `DateTime.Now == DateTime.UtcNow` in practice. However, the code's _intent_ is to log a timestamp: it should explicitly request UTC. If `TZ` were ever set to `America/Vancouver`, all log timestamps would shift by one hour at every DST boundary.
+
+**Remediation applied:**  
+Global replacement of `DateTime.Now` → `DateTime.UtcNow` across all affected source files. Log timestamps now explicitly read from the UTC clock and are DST-immune regardless of any future `TZ` configuration.
+
+---
+
+## Items Confirmed Unaffected
+
+| Item                                                                  | Reason                                                                          |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `CornetDynamicsModel.EventDate`                                       | Already `DateTimeOffset` in all three services — correct                        |
+| `CASAPTransaction` date string fields (`invoiceDate`, `glDate`, etc.) | Date-only strings in format `"21-FEB-2017"` — no time component, DST-irrelevant |
+| `Shared.Database` token cache (`TimeSpan.FromMinutes(5)`)             | Uses `TimeSpan` (duration), not wall-clock time — DST-immune                    |
+| `appsettings.json` (all services)                                     | No timezone, schedule, or local-time references                                 |
+| GitHub Actions CI `cron: "0 3 1,15 * *"`                              | Runs at 03:00 UTC for security scans; no user-facing timing requirement         |
+| `job-scheduling` Dockerfile                                           | Debian base image already includes `tzdata`                                     |
+| Third-party timezone libraries                                        | None present (no NodaTime, TimeZoneConverter, etc.)                             |
+| JWT token validation (`ValidateLifetime = true`)                      | Uses UTC token expiry claims — unaffected by DST                                |
+
+---
+
+## Residual Risk — REQUIRES OPERATOR ACTION
+
+### RISK-01 — MEDIUM — OpenShift CronJob schedule timezone not confirmed
+
+The `promote-job-scheduling-to-prod.yml` workflow describes `job-scheduling` as an **OpenShift CronJob**. The OpenShift CronJob manifest is **not present in this repository**; it is deployed separately to the cluster.
+
+**Risk:** By default, Kubernetes/OpenShift CronJob schedules are evaluated in **UTC**. If the job is intended to run at a specific Pacific local time (e.g., 08:00 PST / 07:00 PDT), the cron expression must either:
+
+1. Be adjusted manually twice a year when clocks change, **or**
+2. Use the `timeZone: America/Vancouver` field on the CronJob spec (available in Kubernetes ≥ 1.25 / OpenShift ≥ 4.12).
+
+**Action required:** Audit the live OpenShift CronJob definition (e.g., `oc get cronjob job-scheduling -o yaml`) and confirm whether a `timeZone:` field is set. If the scheduled firing time must track Pacific local time, add `timeZone: America/Vancouver` to the CronJob spec.
+
+#### Effect of BC permanently eliminating DST
+
+If BC adopts a **permanent fixed UTC offset** (either UTC-8 or UTC-7 year-round), RISK-01 requires a **one-time correction** and then becomes permanently simpler:
+
+- Determine the permanent offset BC adopts (UTC-8 = permanent PST, or UTC-7 = permanent PDT).
+- Update the cron expression to the single fixed UTC equivalent of the desired Pacific fire time. For example, a job targeting 08:00 Pacific needs `0 16 * * *` for permanent UTC-8, or `0 15 * * *` for permanent UTC-7.
+- After that correction, no further twice-yearly adjustments are ever needed.
+- The `timeZone: America/Vancouver` field may be left in place (it will remain valid once `tzdata` is updated) or removed in favour of the hardcoded UTC expression.
+
+**Additional requirement — tzdata currency:**  
+The `tzdata` package installed in the Alpine images (added by FINDING-02) must be **current enough to include BC's new permanent-offset rule** for `America/Vancouver`. An image built before the updated `tzdata` is published will still apply the old DST transition rules. A forced image rebuild must be triggered on or after the date the updated `tzdata` package is released with BC's rule change.
+
+---
+
+## Testing Guidance
+
+To verify correct processing across the DST transition boundary:
+
+1. **`event_dtm` field (FINDING-01):** POST a `CornetTransaction` payload with each of the following timestamp formats and confirm the `EventDate` in the Dynamics write carries the correct UTC offset:
+   - `"2024-03-10T02:30:00"` (no offset — now deserialises as `DateTimeOffset` with `+00:00`)
+   - `"2024-03-10T02:30:00-08:00"` (explicit PST offset)
+   - `"2024-03-10T09:30:00Z"` (UTC)
+
+2. **Container timezone (`tzdata`):** After rebuilding the Alpine images, run:
+
+   ```
+   dotnet -e 'Console.WriteLine(TimeZoneInfo.FindSystemTimeZoneById("America/Vancouver").DisplayName);'
+   ```
+
+   inside the container. It should print the Pacific timezone display name without exception.
+
+3. **Log timestamps (FINDING-03):** Trigger a controller action and confirm log lines contain UTC timestamps (ending in `Z` or matching UTC wall clock).
+
+4. **CronJob schedule (RISK-01):** Run the job manually at 01:59 UTC and 02:01 UTC on the second Sunday of March (spring-forward day). Verify it fires as expected and the Dynamics job executes without error.
+
+---
+
+## Summary Table
+
+| ID         | Severity | Description                                       | Status                                                  |
+| ---------- | -------- | ------------------------------------------------- | ------------------------------------------------------- |
+| FINDING-01 | HIGH     | `CornetTransaction.event_dtm` typed as `DateTime` | ✅ Fixed — changed to `DateTimeOffset` in 3 files       |
+| FINDING-02 | MEDIUM   | Alpine Dockerfiles missing `tzdata`               | ✅ Fixed — `apk add tzdata` added to 3 Dockerfiles      |
+| FINDING-03 | LOW      | `DateTime.Now` in log statements                  | ✅ Fixed — replaced with `DateTime.UtcNow` in 7 files   |
+| RISK-01    | MEDIUM   | OpenShift CronJob `timeZone:` not confirmed       | ⚠️ Open — operator must audit live cluster CronJob spec |


### PR DESCRIPTION
- Changed `event_dtm` property type from `DateTime` to `DateTimeOffset` in CornetTransaction models across AEMInterfaceService, CASInterfaceService, and CornetInterfaceService to ensure correct handling of time zones and avoid DST-related issues.
- Updated logging statements in various controllers to use `DateTime.UtcNow` instead of `DateTime.Now` to ensure consistent UTC timestamps in logs, preventing potential discrepancies during DST transitions.
- Added `tzdata` package installation to Dockerfiles for AEMInterfaceService, CASInterfaceService, and CornetInterfaceService to support timezone operations and prevent runtime exceptions related to timezone lookups.
- Created a DST Impact Scan report documenting findings and remediations related to DST handling across the services.

## Description

:information_source: [**VS-7481**](https://jira.justice.gov.bc.ca/browse/VS-7481)  

This pull request updates the application to use UTC timestamps in all log output for better consistency and accuracy, and ensures timezone data is available in the Docker image for correct timezone resolution.

Logging and Timezone Handling Improvements:

* All `Console.WriteLine` and `Console.Out.WriteLine` statements in `AEMTransactionController.cs` now use `DateTime.UtcNow` instead of `DateTime.Now` to ensure logging is always in UTC, which avoids ambiguity and makes log analysis easier across different environments. [[1]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L44-R91) [[2]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L100-R141) [[3]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L154-R154) [[4]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L183-R188) [[5]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L198-R198) [[6]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L208-R208) [[7]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L223-R231) [[8]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L241-R250) [[9]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L259-R266) [[10]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L278-R280) [[11]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L303-R303) [[12]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L319-R322) [[13]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L335-R335) [[14]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L350-R350) [[15]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L360-R382) [[16]](diffhunk://#diff-9af3699fdd3c8477f0fba009b43e24becf9111dbed1d4640f2c2432b1ecbc2d8L392-R392)

* The Dockerfile for the service now installs the `tzdata` package, ensuring that .NET's `TimeZoneInfo` can resolve IANA timezone names correctly on Alpine Linux. This is important for any future timezone conversions or operations that depend on timezone data.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
